### PR TITLE
Updated Android plugin for Gradle

### DIFF
--- a/backup-codelab-done/app/build.gradle
+++ b/backup-codelab-done/app/build.gradle
@@ -16,7 +16,6 @@ apply plugin: 'com.android.application'
 
 android {
     compileSdkVersion 26
-    buildToolsVersion "26.0.1"
     defaultConfig {
         applicationId "com.googlecodelabs.example.backupexample"
         minSdkVersion 22

--- a/backup-codelab-done/build.gradle
+++ b/backup-codelab-done/build.gradle
@@ -21,7 +21,7 @@ buildscript {
         jcenter()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:3.0.0-beta3'
+        classpath 'com.android.tools.build:gradle:3.0.0-beta7'
         
 
         // NOTE: Do not place your application dependencies here; they belong

--- a/backup-codelab-start/app/build.gradle
+++ b/backup-codelab-start/app/build.gradle
@@ -16,7 +16,6 @@ apply plugin: 'com.android.application'
 
 android {
     compileSdkVersion 26
-    buildToolsVersion "26.0.1"
     defaultConfig {
         applicationId "com.googlecodelabs.example.backupexample"
         minSdkVersion 22

--- a/backup-codelab-start/build.gradle
+++ b/backup-codelab-start/build.gradle
@@ -21,7 +21,7 @@ buildscript {
         jcenter()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:3.0.0-beta3'
+        classpath 'com.android.tools.build:gradle:3.0.0-beta7'
         
 
         // NOTE: Do not place your application dependencies here; they belong


### PR DESCRIPTION
Updated Android plugin for Gradle and removed android.buildToolsVersion parameter as it is optional from now on.

https://androidstudio.googleblog.com/2017/10/android-studio-30-beta-7-is-now.html

The same changeset as in https://github.com/googlecodelabs/android-backup-codelab/pull/1, just with correct user email set